### PR TITLE
docs: update theme 1.5

### DIFF
--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -7,13 +7,13 @@ authors = ["ScyllaDB Documentation Contributors"]
 [tool.poetry.dependencies]
 python = "^3.7"
 pyyaml = "6.0"
-pygments = "2.11.2"
+pygments = "2.15.1"
 recommonmark = "0.7.1"
-sphinx-scylladb-theme = "~1.3.1"
+sphinx-scylladb-theme = "~1.5.1"
 sphinx-autobuild = "2021.3.14"
 Sphinx = "4.3.2"
 sphinx-multiversion-scylla = "~0.2.11"
-sphinx-sitemap = "2.2.0"
+sphinx-sitemap = "2.5.0"
 redirects_cli ="~0.1.3"
 
 [build-system]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -105,6 +105,7 @@ html_static_path = ["_static"]
 html_theme_options = {
     "conf_py_path": "docs/source/",
     "hide_edit_this_page_button": "false",
+    "hide_feedback_buttons": "false",
     "github_issues_repository": "scylladb/scylladb-feature-store",
     "github_repository": "scylladb/scylladb-feature-store",
     "site_description": "ScyllaDB feature store example.",


### PR DESCRIPTION
Related issue https://github.com/scylladb/sphinx-scylladb-theme/issues/774

ScyllaDB Sphinx Theme 1.5 is now released 🥳 This update introduces an interactive feature to receive feedback, allowing readers to like or dislike documentation pages. It also includes subtle user interface enhancements and resolves an existing issue related to the sitemap extension. 

You can read more about all notable changes [here](https://sphinx-theme.scylladb.com/master/upgrade/CHANGELOG.html#may-2023).

## How to test this PR

1. Clone this PR. For more information, see [Cloning pull requests locally](https://docs.github.com/en/github/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/checking-out-pull-requests-locally).

2. Enter the docs folder, and run:
  
    ```
    make preview
    ````

3. Open http://localhost:5500 with your favorite browser. The doc should render without errors, and the version should be Sphinx Theme version (see the footer) must be ``1.5.x``:

    ![image](https://github.com/scylladb/python-driver/assets/9107969/f076ba3c-62a8-4b96-9ab0-d51dfbd22a51)
